### PR TITLE
Use WebSphere Liberty helm chart to deploy portfolio microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ providers simply means updating the *Dockerfile* to copy the *JDBC* jar file int
 the *server.xml* to reference it and specify any database-specific settings.  No *Java* code changes are necessary
 when changing *JDBC* providers.  The database can either be another pod in the same *Kubernetes* environment, or
 it can be running on "bare metal" in a traditional on-premises environment.  Endpoint and credential info is
-specified in the *Kubernetes* secret and made available as environment variables to the server.xml.  See the
-*deploy.yaml* for details.
+specified in the *Kubernetes* secret and made available as environment variables to the server.xml of WebSphere Liberty.  See the
+*manifests/portfolio-values.yaml* for details.
 
 ### Prerequisites for ICP Deployment
  This project requires two secrets: `jwt` and `db2`.  You can get the DB2 values from inspecting your DB2 secrets.
@@ -73,14 +73,18 @@ specified in the *Kubernetes* secret and made available as environment variables
   ```
  
  ### Build and Deploy to ICP
-To build `trader` clone this repo and run:
+To build `portfolio` clone this repo and run:
 ```bash
 mvn package
 docker build -t portfolio:latest -t <ICP_CLUSTER>.icp:8500/stock-trader/portfolio:latest .
 docker tag portfolio:latest <ICP_CLUSTER>.icp:8500/stock-trader/portfolio:latest
 docker push <ICP_CLUSTER>.icp:8500/stock-trader/portfolio:latest
+```
 
-kubectl apply -f manifests/
+Use WebSphere Liberty helm chart to deploy Portfolio microservice to ICP:
+```bash
+helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+helm install ibm-charts/ibm-websphere-liberty -f <VALUES_YAML> -n <RELEASE_NAME> --tls
 ```
 
 In practice this means you'll run something like:
@@ -89,5 +93,6 @@ docker build -t portfolio:latest -t mycluster.icp:8500/stock-trader/portfolio:la
 docker tag portfolio:latest mycluster.icp:8500/stock-trader/portfolio:latest
 docker push mycluster.icp:8500/stock-trader/portfolio:latest
 
-kubectl --namespace stock-trader apply -f manifests/
+helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+helm install ibm-charts/ibm-websphere-liberty -f manifests/portfolio-values.yaml -n portfolio --namespace stock-trader --tls
 ```

--- a/manifests/portfolio-values.yaml
+++ b/manifests/portfolio-values.yaml
@@ -1,0 +1,179 @@
+#       Copyright 2017 IBM Corp All Rights Reserved
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+################################################################################################
+## Configuration for deploying Stock Portfolio microservice using WebSphere Liberty helm chart
+################################################################################################
+
+image:
+  # repository: portfolio # Microservice Builder
+  # repository: mycluster.icp:8500/stock-trader/portfolio # IBM Cloud Private
+  # repository: registry.ng.bluemix.net/stock_trader/portfolio # IBM Container Service
+  repository: ibmstocktrader/portfolio # Docker Hub
+  tag: latest
+  pullPolicy: Always
+  extraEnvs:
+    - name: JDBC_HOST
+      valueFrom:
+        secretKeyRef:
+          name: db2
+          key: host
+    - name: JDBC_PORT
+      valueFrom:
+        secretKeyRef:
+          name: db2
+          key: port
+    - name: JDBC_DB
+      valueFrom:
+        secretKeyRef:
+          name: db2
+          key: db
+    - name: JDBC_ID
+      valueFrom:
+        secretKeyRef:
+          name: db2
+          key: id
+    - name: JDBC_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: db2
+          key: pwd
+    - name: MQ_ID
+      valueFrom:
+        secretKeyRef:
+          name: mq
+          key: id
+    - name: MQ_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: mq   
+          key: pwd
+    - name: MQ_HOST
+      valueFrom:
+        secretKeyRef:
+          name: mq
+          key: host
+    - name: MQ_PORT
+      valueFrom:
+        secretKeyRef:
+          name: mq   
+          key: port
+    - name: MQ_CHANNEL
+      valueFrom:
+        secretKeyRef:
+          name: mq   
+          key: channel
+    - name: MQ_QUEUE_MANAGER
+      valueFrom:
+        secretKeyRef:
+          name: mq   
+          key: queue-manager
+    - name: MQ_QUEUE
+      valueFrom:
+          secretKeyRef:
+            name: mq   
+            key: queue
+    - name: WATSON_URL
+      valueFrom:
+        secretKeyRef:
+          name: watson
+          key: url
+    - name: WATSON_ID
+      valueFrom:
+        secretKeyRef:
+          name: watson
+          key: id
+    - name: WATSON_PWD
+      valueFrom:
+        secretKeyRef:
+          name: watson
+          key: pwd
+    - name: ODM_URL
+      valueFrom:
+        secretKeyRef:
+          name: odm
+          key: url
+          optional: true
+    - name: ODM_ID
+      valueFrom:
+        secretKeyRef:
+          name: odm
+          key: id
+          optional: true
+    - name: ODM_PWD
+      valueFrom:
+        secretKeyRef:
+          name: odm
+          key: pwd
+          optional: true
+    - name: KAFKA_TOPIC
+      valueFrom:
+        secretKeyRef:
+          name: kafka
+          key: topic
+          optional: true
+    - name: KAFKA_ADDRESS
+      valueFrom:
+        secretKeyRef:
+          name: kafka
+          key: address
+          optional: true
+    - name: KAFKA_USER
+      valueFrom:
+        secretKeyRef:
+          name: kafka
+          key: user
+          optional: true
+    - name: KAFKA_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: kafka
+          key: api-key
+          optional: true
+    - name: JWT_AUDIENCE
+      valueFrom:
+        secretKeyRef:
+          name: jwt 
+          key: audience
+    - name: JWT_ISSUER
+      valueFrom:
+        secretKeyRef:
+          name: jwt
+          key: issuer
+
+resourceNameOverride: stock-trader
+
+pod:
+  labels:
+    solution: stock-trader
+
+service:
+  enabled: true
+  name: portfolio-service
+  port: 9443
+  targetPort: 9443
+  type: NodePort
+  extraPorts:
+    - name: portfolio-service-http
+      protocol: TCP
+      port: 9080
+      targetPort: 9080
+
+ingress:
+  enabled: true 
+  path: "/portfolio"
+  annotations: 
+    ingress.kubernetes.io/app-root: "/portfolio"
+    nginx.ingress.kubernetes.io/app-root: "/portfolio"


### PR DESCRIPTION
Using the official WebSphere Liberty helm chart to deploy the portfolio microservice, which is running on WebSphere Liberty, is ideal. WebSphere Liberty helm chart version 1.7.0 added various hooks to allow users provide additional kubernetes resources/logic (e.g. environment variables, extra ports, annotations, server configuration), which can be utilized by portfolio microservice to configure necessary resources.