### PR TITLE
Propagates CR value of `kafka.historyTopic` to environment variable `KAFKA_HISTORY_TOPIC` for the `portfolio`

### DIFF
--- a/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/portfolio/PortfolioService.java
+++ b/src/main/java/com/ibm/hybrid/cloud/sample/stocktrader/portfolio/PortfolioService.java
@@ -117,7 +117,7 @@ public class PortfolioService extends Application {
 
 	private @Inject @RestClient StockQuoteClient stockQuoteClient;
 
-	private @Inject @ConfigProperty(name = "KAFKA_TOPIC", defaultValue = "stocktrader") String kafkaTopic;
+	private @Inject @ConfigProperty(name = "KAFKA_HISTORY_TOPIC", defaultValue = "stocktrader") String kafkaTopic;
 	private @Inject @ConfigProperty(name = "KAFKA_ADDRESS", defaultValue = "") String kafkaAddress;
 
 	private static boolean publishToTradeHistoryTopic;


### PR DESCRIPTION
This allows for consistent configuration of kafka topics between `portfolio` and `trade-history`.

This PR fixes issue #44.